### PR TITLE
Fix sections on CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,11 +137,11 @@
 
 Bump to require Elixir 1.11. Now official support has been updated to Elixir 1.11+ with OTP 23+
 
-## 📝 Documentation
+### 📝 Documentation
 
 - doc: correct tags example for Adapters.Sendinblue @03juan (#711)
 
-## 🧰 Maintenance
+### 🧰 Maintenance
 
 - Bump ex\_doc from 0.28.4 to 0.28.5 @dependabot (#712)
 - Bump ex\_aws from 2.3.3 to 2.3.4 @dependabot (#710)


### PR DESCRIPTION
The 1.7.5 version had the subsection levels wrong (h2 instead of h3).

See:
![image](https://github.com/nelsonmestevao/swoosh/assets/19409687/b46e5667-a462-4219-b871-258bc467676e)
